### PR TITLE
Added a counter to see how many transactions has been pushed.

### DIFF
--- a/hammer/send.py
+++ b/hammer/send.py
@@ -204,7 +204,7 @@ def many_transactions_consecutive(contract, numTx):
     txs = []
     for i in range(numTx):
         tx = contract_set(contract, i)
-        print ("set() transaction submitted: ", tx) # Web3.toHex(tx)) # new web3
+        print (i, " set() transaction submitted: ", tx) # Web3.toHex(tx)) # new web3
         txs.append(tx)
     return txs
         


### PR DESCRIPTION
Added a counter to show the number of transaction we are sending. E.g. In some experiments, we stopped mining and continued sending transactions but submission slowed down after certain no of transactions (5K or so) probably because of the eth node meomory etc. Having a counter will let us see how many we already sent